### PR TITLE
Fix deprecated 'set-output' in workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -35,6 +35,7 @@ env:
 
 jobs:
   build:
+    timeout-minutes: 30
     env:
       CARGO_TERM_COLOR: always
       PROTOC_NO_VENDOR: true
@@ -190,4 +191,3 @@ jobs:
         asset_name: v2ray-rust-${{ steps.get_version.outputs.VERSION }}-${{ matrix.config.artifact }}.7z
         tag: ${{ github.ref }}
         overwrite: true
-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ on:
   workflow_dispatch:
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,9 @@ on:
   # For test
   workflow_dispatch:
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
 
     - name: Get rust version
       id: rust-version
-      run: echo "::set-output name=version::$(rustc --version)"
+      run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
 
     - name: Cache cargo index
       uses: actions/cache@v3.0.11
@@ -176,7 +176,7 @@ jobs:
     - name: Get the version
       if: github.event_name == 'release' && matrix.config.has_release
       id: get_version
-      run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      run: echo VERSION=$(echo $GITHUB_REF | cut -d / -f 3) >> $GITHUB_OUTPUT
     
     - name: Upload to GitHub Release
       uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
According to GitHub, [the `set-output` command is deprecated and will be disabled soon](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

This PR tries to fix currently used `set-output` commands in the workflow.
