### PR TITLE
Bump possibly deprecated workflow actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,7 +93,7 @@ jobs:
       run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
 
     - name: Cache cargo index
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/registry/index
         key: index-${{ runner.os }}-${{ github.run_number }}
@@ -104,7 +104,7 @@ jobs:
           #      run: cargo generate-lockfile
       
     - name: Cache cargo registry
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4
       with:
         path: ~/.cargo/registry/cache
         key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
@@ -113,7 +113,7 @@ jobs:
       run: cargo fetch
     
     - name: Cache target directory
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4
       with:
         path: target
         key: cache-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,7 +172,7 @@ jobs:
     
     
     - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: v2ray-rust-${{ github.sha }}-${{ matrix.config.artifact }}.7z
         path: release-tmp


### PR DESCRIPTION
See [actions/upload-artifact](https://github.com/actions/upload-artifact) and [actions/cache](https://github.com/actions/cache).